### PR TITLE
feat: added trpc 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ With tRPC we get the same benefits as with GraphQL and more (minus the code gene
 * Simple: tRPC solely relies on Typescript to ensure the client-server contract is valid - no code generators, no schema declarations required.
 * Performance: tRPC has great support for server-side rendering. If the Forge ecosystem supports server-side rendering, I am sure tRPC will be able to leverage that.
 * Developer ergonomics: Through the tRCP interface, IDEs will provide code completion for available Forge functions and even support jump-to-source (server) from Custom UI code.
+
+## tRPC v11
+Starting version 1.0.0 this packages supports tRPC v11 [which is considered stable](https://trpc.io/docs/migrate-from-v10-to-v11). This package is currently tested with 11.0.0-rc.593. Be aware that you'll need to use React 18.x to use tRPC 11.x with react-query 5.x. If you spot any issues with tRPC 11.x please open an issue. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@forge/bridge": "^3.3.0",
         "@forge/resolver": "^1.5.29",
-        "@trpc/client": "^10.45.2",
-        "@trpc/server": "^10.45.2",
+        "@trpc/client": "^11.0.0-rc.593",
+        "@trpc/server": "^11.0.0-rc.593",
         "fp-ts": "^2.13.1",
         "io-ts": "^2.2.20",
         "tslib": "^2.3.0"
@@ -4281,23 +4281,25 @@
       }
     },
     "node_modules/@trpc/client": {
-      "version": "10.45.2",
-      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-10.45.2.tgz",
-      "integrity": "sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==",
+      "version": "11.0.0-rc.593",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.0.0-rc.593.tgz",
+      "integrity": "sha512-uQORhYMwUeY4TluQmhl6N183BiLZz5mgIzBynkSWKxtQ7TIHt+3iRzTSiJH1jTl3SEOtCacRHS6b1yvFP2RJXw==",
       "funding": [
         "https://trpc.io/sponsor"
       ],
+      "license": "MIT",
       "peerDependencies": {
-        "@trpc/server": "10.45.2"
+        "@trpc/server": "11.0.0-rc.593+f73cd3fd9"
       }
     },
     "node_modules/@trpc/server": {
-      "version": "10.45.2",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.45.2.tgz",
-      "integrity": "sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==",
+      "version": "11.0.0-rc.593",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.0.0-rc.593.tgz",
+      "integrity": "sha512-ihZNf7nM3OriZkkuOUFjuB51FJdtCXZUUj8FIXkq0VXF9VmMOD7j4QTl5YojIzMTJBMGUK9VADcO0shgELEmyw==",
       "funding": [
         "https://trpc.io/sponsor"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -16126,15 +16128,15 @@
       "dev": true
     },
     "@trpc/client": {
-      "version": "10.45.2",
-      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-10.45.2.tgz",
-      "integrity": "sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==",
+      "version": "11.0.0-rc.593",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.0.0-rc.593.tgz",
+      "integrity": "sha512-uQORhYMwUeY4TluQmhl6N183BiLZz5mgIzBynkSWKxtQ7TIHt+3iRzTSiJH1jTl3SEOtCacRHS6b1yvFP2RJXw==",
       "requires": {}
     },
     "@trpc/server": {
-      "version": "10.45.2",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.45.2.tgz",
-      "integrity": "sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg=="
+      "version": "11.0.0-rc.593",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.0.0-rc.593.tgz",
+      "integrity": "sha512-ihZNf7nM3OriZkkuOUFjuB51FJdtCXZUUj8FIXkq0VXF9VmMOD7j4QTl5YojIzMTJBMGUK9VADcO0shgELEmyw=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,5 @@
   },
   "nx": {
     "includedScripts": []
-  },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@forge/bridge": "^3.3.0",
     "@forge/resolver": "^1.5.29",
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2",
+    "@trpc/client": "^11.0.0-rc.593",
+    "@trpc/server": "^11.0.0-rc.593",
     "fp-ts": "^2.13.1",
     "io-ts": "^2.2.20",
     "tslib": "^2.3.0"
@@ -47,5 +47,6 @@
   },
   "nx": {
     "includedScripts": []
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/packages/forge-trpc-adapter/README.md
+++ b/packages/forge-trpc-adapter/README.md
@@ -27,6 +27,7 @@ import {
   CreateForgeContextOptions
 } from '@toolsplus/forge-trcp-adapter';
 import { z } from 'zod';
+import superjson from 'superjson';
 
 // Initialize a context for the server
 const createContext = ({ request }: CreateForgeContextOptions) => {
@@ -37,9 +38,11 @@ const createContext = ({ request }: CreateForgeContextOptions) => {
 }
 
 // Get the context type
-type Context = inferAsyncReturnType<typeof createContext>;
+type Context = Awaited<ReturnType<typeof createContext>>;
 
-const tRPC = initTRPC.context<Context>().create();
+const tRPC = initTRPC.context<Context>().create({
+  transformer: superjson
+});
 
 // Create hello router
 const helloRouter = tRPC.router({

--- a/packages/forge-trpc-adapter/package.json
+++ b/packages/forge-trpc-adapter/package.json
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "@forge/resolver": "^1.4.8",
-    "@trpc/server": "^10.7.0",
+    "@toolsplus/forge-trpc-protocol": "0.0.0-development",
+    "@trpc/server": "^11.0.0-rc.593",
     "fp-ts": "^2.13.1",
     "io-ts": "^2.2.20",
-    "tslib": "^2.3.0",
-    "@toolsplus/forge-trpc-protocol": "0.0.0-development"
+    "tslib": "^2.3.0"
   }
 }

--- a/packages/forge-trpc-adapter/src/lib/resolve-procedure-call.ts
+++ b/packages/forge-trpc-adapter/src/lib/resolve-procedure-call.ts
@@ -7,16 +7,16 @@ import { pipe } from 'fp-ts/function';
 import * as PathReporter from 'io-ts/PathReporter';
 import {
   AnyRouter,
-  callProcedure,
+  callProcedure, getErrorShape,
   inferRouterContext,
   inferRouterError,
-  TRPCError,
+  TRPCError
 } from '@trpc/server';
 import { TRPCResponse } from '@trpc/server/rpc';
 import {
   ProcedureCallOptions,
   procedureCallOptionsCodec,
-  ProcedureType,
+  ProcedureType
 } from '@toolsplus/forge-trpc-protocol';
 import { getTRPCErrorFromUnknown } from './error-util';
 import { transformTRPCResponse } from './transform-trpc-response';
@@ -47,8 +47,8 @@ const decodeProcedureCallOptions = (
         code: 'BAD_REQUEST',
         message: `Unexpected RPC payload: ${PathReporter.failure(
           validationError
-        ).join(', ')}`,
-      }),
+        ).join(', ')}`
+      })
     }))
   );
 };
@@ -60,25 +60,25 @@ const validateProcedureCallOptions = (
   if (callOptions.isBatchCall && !batchingEnabled) {
     return E.left({
       error: new Error(`Batching is not enabled on the server`),
-      callOptions,
+      callOptions
     });
   }
   if (callOptions.type === 'subscription') {
     return E.left({
       error: new TRPCError({
         message: 'Subscriptions should use wsLink',
-        code: 'METHOD_NOT_SUPPORTED',
+        code: 'METHOD_NOT_SUPPORTED'
       }),
-      callOptions,
+      callOptions
     });
   }
   return E.right(callOptions);
 };
 
 const getInputs = <TRouter extends AnyRouter>({
-  callOptions,
-  router,
-}: {
+                                                callOptions,
+                                                router
+                                              }: {
   callOptions: ProcedureCallOptions;
   router: TRouter;
 }): E.Either<ProcedureCallError, Record<number, unknown>> => {
@@ -90,7 +90,7 @@ const getInputs = <TRouter extends AnyRouter>({
     },
     (error): ProcedureCallError => ({
       error: error as Error,
-      callOptions,
+      callOptions
     })
   );
 
@@ -98,7 +98,7 @@ const getInputs = <TRouter extends AnyRouter>({
     return pipe(
       deserializeInputValue(callOptions.input),
       E.map((value) => ({
-        0: value,
+        0: value
       }))
     );
   }
@@ -111,9 +111,9 @@ const getInputs = <TRouter extends AnyRouter>({
     return E.left({
       error: new TRPCError({
         code: 'BAD_REQUEST',
-        message: '"input" needs to be an object when doing a batch call',
+        message: '"input" needs to be an object when doing a batch call'
       }),
-      callOptions,
+      callOptions
     });
   }
   const inputValidation = batchInputCodec.decode(callOptions.input);
@@ -122,9 +122,9 @@ const getInputs = <TRouter extends AnyRouter>({
       error: new TRPCError({
         code: 'BAD_REQUEST',
         message:
-          '"input" object keys need to be numbers when doing a batch call',
+          '"input" object keys need to be numbers when doing a batch call'
       }),
-      callOptions,
+      callOptions
     });
   }
 
@@ -135,14 +135,14 @@ const getInputs = <TRouter extends AnyRouter>({
       R.isEmpty(left)
         ? E.right(right)
         : E.left({
-            error: new Error(
-              `Batch input deserialization failed on the following inputs:\n
+          error: new Error(
+            `Batch input deserialization failed on the following inputs:\n
                     ${Object.entries(left)
-                      .map(([key, e]) => `[${key}]: ${e.error}`)
-                      .join('\n')}`
-            ),
-            callOptions,
-          })
+              .map(([key, e]) => `[${key}]: ${e.error}`)
+              .join('\n')}`
+          ),
+          callOptions
+        })
   );
 };
 
@@ -151,12 +151,12 @@ type ProcedureCallResult =
   | { type: 'data'; input: unknown; path: string; data: unknown };
 
 const callProcedures = <TRouter extends AnyRouter>({
-  callOptions,
-  inputs,
-  router,
-  ctx,
-  onError,
-}: {
+                                                     callOptions,
+                                                     inputs,
+                                                     router,
+                                                     ctx,
+                                                     onError
+                                                   }: {
   callOptions: ProcedureCallOptions;
   inputs: Record<number, unknown>;
   router: TRouter;
@@ -177,9 +177,10 @@ const callProcedures = <TRouter extends AnyRouter>({
             callProcedure({
               procedures: router._def.procedures,
               path,
-              rawInput: input,
+              getRawInput: async () => input,
               ctx,
               type: callOptions.type,
+              signal: undefined
             }),
           (cause) => {
             const error = getTRPCErrorFromUnknown(cause);
@@ -188,7 +189,7 @@ const callProcedures = <TRouter extends AnyRouter>({
               path,
               input,
               ctx,
-              type: callOptions.type,
+              type: callOptions.type
             });
             return error;
           }
@@ -198,13 +199,13 @@ const callProcedures = <TRouter extends AnyRouter>({
             type: 'error',
             input,
             path,
-            error,
+            error
           }),
           (output) => ({
             type: 'data',
             input,
             path,
-            data: output,
+            data: output
           })
         )
       )
@@ -214,11 +215,11 @@ const callProcedures = <TRouter extends AnyRouter>({
 };
 
 const toTRPCResponse = <TRouter extends AnyRouter>({
-  callResult,
-  router,
-  callOptions,
-  ctx,
-}: {
+                                                     callResult,
+                                                     router,
+                                                     callOptions,
+                                                     ctx
+                                                   }: {
   callResult: ProcedureCallResult;
   router: TRouter;
   callOptions: ProcedureCallOptions;
@@ -227,19 +228,20 @@ const toTRPCResponse = <TRouter extends AnyRouter>({
   const { path, input } = callResult;
   if (callResult.type === 'error') {
     return {
-      error: router.getErrorShape({
+      error: getErrorShape({
+        config: router._def._config,
         error: callResult.error,
         type: callOptions.type,
         path,
         input,
-        ctx,
-      }),
+        ctx
+      })
     };
   } else {
     return {
       result: {
-        data: callResult.data,
-      },
+        data: callResult.data
+      }
     };
   }
 };
@@ -322,11 +324,11 @@ export const resolveProcedureCall = async <TRouter extends AnyRouter>(
           type: cause.callOptions?.type ?? ('unknown' as const),
           path: cause.callOptions?.path ?? undefined,
           input: cause.callOptions?.input ?? undefined,
-          ctx,
+          ctx
         };
         onError?.(errorMeta);
         return transformResponse(router, {
-          error: router.getErrorShape(errorMeta),
+          error: getErrorShape({ ...errorMeta, config: router._def._config })
         });
       },
       ({ resultEnvelopes, callOptions }) =>

--- a/packages/forge-trpc-link/README.md
+++ b/packages/forge-trpc-link/README.md
@@ -6,6 +6,7 @@ Custom [tRPC link](https://trpc.io/docs/links) to enable tRPC for [Atlassian For
 
 ```shell
 npm install @toolsplus/forge-trpc-link
+npm install superjson
 ```
 
 Note that this package has a peer dependency on `@forge/bridge`. If you have not installed `@forge/bridge` you may install before installing this package.
@@ -15,17 +16,65 @@ Note that this package has a peer dependency on `@forge/bridge`. If you have not
 You can import and add the `customUiBridgeLink` to the links array as follows:
 
 ```typescript
-import { createTRPCProxyClient } from '@trpc/client';
-import { customUiBridgeLink } from '@toolsplus/forge-trcp-link';
+// trpc-client.ts
+import { createTRPCClient } from '@trpc/client';
+import { customUiBridgeLink } from '@toolsplus/forge-trpc-link';
 import type { HelloRouter } from '../my-trpc-server';
+import superjson from 'superjson';
 
-const client = createTRPCProxyClient<HelloRouter>({
+export const trpcClient = createTRPCClient<HelloRouter>({
   links: [
     customUiBridgeLink({
-      resolverFunctionKey: 'rpc' 
+      resolverFunctionKey: 'rpc' ,
+      transformer: superjson,
     }),
   ],
 });
+```
+
+## Usage with @trpc/react-query (optional)
+react-query is a popular library for managing server state in React applications. You can use `@trpc/react-query` to integrate tRPC with react-query.
+You will need react-query 5 and React 18 to use this.
+
+Instantiate the tRPC client with the `customUiBridgeLink` as shown below:
+```typescript
+// trpc-client.ts
+import { createTRPCReact } from '@trpc/react-query';
+import { customUiBridgeLink } from '@toolsplus/forge-trpc-link';
+import type { HelloRouter } from '../my-trpc-server';
+import superjson  from 'superjson';
+
+export const trpcReact = createTRPCReact<HelloRouter>();
+export const trpcReactClient = trpcReact.createClient({
+  links: [
+    customUiBridgeLink({
+      resolverFunctionKey: 'rpc',
+      transformer: superjson,
+    }),
+  ],
+})
+```
+Wrap your application with the `TRPCProvider` as shown below:
+```tsx
+import { trpcReact, trpcReactClient } from "./trpc-client";
+
+const queryClient = new QueryClient();
+
+export default function App() {
+  return (
+    <trpcReact.Provider client={trpcReactClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        ... 
+      </QueryClientProvider>
+    </trpcReact.Provider>
+  )
+}
+```
+Then consume the typed queries and mutations in your components as shown below:
+```tsx
+const query = trpcReact.greeting.useQuery({ name: 'result from trpc provided query!' });
+// or even use suspense
+const suspenseQuery = trpcReact.greeting.useSuspenseQuery();
 ```
 
 ## `customUiBridgeLink` options
@@ -41,6 +90,15 @@ interface CustomUiBridgeLinkOptions {
    * @defaultValue 'rpc'
    */
   resolverFunctionKey?: string;
+  /**
+   * The transformer to use for serializing and deserializing 
+   * tRPC requests and responses. You usually want to use superjson.
+   *
+   */
+  transformer: {
+    serialize: (object: any) => any;
+    deserialize: (object: any) => any;
+  };
 }
 ```
 

--- a/packages/forge-trpc-link/package.json
+++ b/packages/forge-trpc-link/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@forge/bridge": "^3.3.0",
-    "@trpc/client": "^10.7.0",
-    "@trpc/server": "^10.7.0",
-    "tslib": "^2.3.0",
-    "@toolsplus/forge-trpc-protocol": "0.0.0-development"
+    "@toolsplus/forge-trpc-protocol": "0.0.0-development",
+    "@trpc/client": "^11.0.0-rc.593",
+    "@trpc/server": "^11.0.0-rc.593",
+    "tslib": "^2.3.0"
   }
 }

--- a/packages/forge-trpc-link/src/lib/custom-ui-bridge-request.spec.ts
+++ b/packages/forge-trpc-link/src/lib/custom-ui-bridge-request.spec.ts
@@ -1,4 +1,3 @@
-import { TRPCClientRuntime } from '@trpc/client';
 import { defaultResolverFunctionKey } from '@toolsplus/forge-trpc-protocol';
 
 const invokeMock = jest.fn();
@@ -7,21 +6,11 @@ jest.mock('@forge/bridge', () => ({
 }));
 import { customUiBridgeRequest } from './custom-ui-bridge-request';
 
-const mockRuntime: TRPCClientRuntime = {
-  transformer: {
-    serialize: (v) => v,
-    deserialize: (v) => v,
-  },
-  combinedTransformer: {
-    input: {
-      serialize: (v) => v,
-      deserialize: (v) => v,
-    },
-    output: {
-      serialize: (v) => v,
-      deserialize: (v) => v,
-    }
-  }
+type DataTransformer =  Parameters<typeof customUiBridgeRequest>[0]["transformer"];
+
+const mockTransformer: DataTransformer= {
+  serialize: (v) => v,
+  deserialize: (v) => v,
 };
 
 const baseOptions = {
@@ -38,7 +27,8 @@ describe('customUiBridgeRequest', () => {
       } as const;
       await customUiBridgeRequest({
         ...options,
-        runtime: mockRuntime,
+        transformer: mockTransformer,
+        runtime: {},
       });
       expect(invokeMock).toBeCalledWith(
         defaultResolverFunctionKey,
@@ -56,7 +46,8 @@ describe('customUiBridgeRequest', () => {
       } as const;
       await customUiBridgeRequest({
         ...options,
-        runtime: mockRuntime,
+        runtime: {},
+        transformer: mockTransformer,
       });
       expect(invokeMock).toBeCalledWith(
         defaultResolverFunctionKey,
@@ -75,7 +66,8 @@ describe('customUiBridgeRequest', () => {
       } as const;
       await customUiBridgeRequest({
         ...options,
-        runtime: mockRuntime,
+        runtime: {},
+        transformer: mockTransformer,
         resolverFunctionKey: functionKey,
       });
       expect(invokeMock).toBeCalledWith(
@@ -94,13 +86,11 @@ describe('customUiBridgeRequest', () => {
       } as const;
       await customUiBridgeRequest({
         ...options,
-        runtime: {
-          transformer: {
-            serialize: (v) => JSON.stringify(v),
-            deserialize: (v) => v,
-          },
-          combinedTransformer: mockRuntime.combinedTransformer
-        },
+        runtime: {},
+        transformer: {
+          serialize: (v) => JSON.stringify(v),
+          deserialize: (v) => v,
+        }
       });
       expect(invokeMock).toBeCalledWith(
         defaultResolverFunctionKey,
@@ -124,7 +114,8 @@ describe('customUiBridgeRequest', () => {
       } as const;
       await customUiBridgeRequest({
         ...options,
-        runtime: mockRuntime,
+        runtime: {},
+        transformer: mockTransformer,
       });
       expect(invokeMock).toBeCalledWith(
         defaultResolverFunctionKey,
@@ -145,13 +136,11 @@ describe('customUiBridgeRequest', () => {
       } as const;
       await customUiBridgeRequest({
         ...options,
-        runtime: {
-          transformer: {
-            serialize: (v) => JSON.stringify(v),
-            deserialize: (v) => v,
-          },
-          combinedTransformer: mockRuntime.combinedTransformer
-        },
+        runtime: {},
+        transformer: {
+          serialize: (v) => JSON.stringify(v),
+          deserialize: (v) => v,
+        }
       });
       expect(invokeMock).toBeCalledWith(
         defaultResolverFunctionKey,

--- a/packages/forge-trpc-link/src/lib/forge-trpc-link.spec.ts
+++ b/packages/forge-trpc-link/src/lib/forge-trpc-link.spec.ts
@@ -1,4 +1,3 @@
-import { TRPCClientRuntime } from '@trpc/client';
 import { observableToPromise } from '@trpc/server/observable';
 
 const customUiBridgeRequestMock = jest.fn();
@@ -6,23 +5,6 @@ jest.mock('./custom-ui-bridge-request', () => ({
   customUiBridgeRequest: customUiBridgeRequestMock,
 }));
 import { customUiBridgeLink } from './forge-trcp-link';
-
-const mockRuntime: TRPCClientRuntime = {
-  transformer: {
-    serialize: (v) => v,
-    deserialize: (v) => v,
-  },
-  combinedTransformer: {
-    input: {
-      serialize: (v) => v,
-      deserialize: (v) => v,
-    },
-    output: {
-      serialize: (v) => v,
-      deserialize: (v) => v,
-    }
-  }
-};
 
 const tRPCSuccessResponse = <T>({ id, data }: { id: number; data: T }) => ({
   id,
@@ -46,7 +28,13 @@ const tRPCErrorResponse = <T>({
   error: { code, message, data },
 });
 
-const link = customUiBridgeLink({});
+const link = customUiBridgeLink({
+  resolverFunctionKey: 'rpc',
+  transformer: {
+    serialize: (v) => v,
+    deserialize: (v) => v,
+  },
+});
 
 describe('customUiBridgeLink', () => {
   afterEach(() => {
@@ -61,19 +49,19 @@ describe('customUiBridgeLink', () => {
           tRPCSuccessResponse({ id: 123, data: fakeResponseData })
         )
       );
-      const customUiBridgeLinkObservable = link(mockRuntime)({
+      const customUiBridgeLinkObservable = link({})({
         op: {
           id: 123,
           type: 'query',
           input: { one: 'abc', two: 'xyz' },
           path: 'test',
           context: {},
+          signal: undefined,
         },
         next: jest.fn(),
       });
 
-      const result = await observableToPromise(customUiBridgeLinkObservable)
-        .promise;
+      const result = await observableToPromise(customUiBridgeLinkObservable);
 
       expect(result).toEqual({
         result: {
@@ -90,25 +78,26 @@ describe('customUiBridgeLink', () => {
           tRPCSuccessResponse({ id: 123, data: fakeResponseData })
         )
       );
-      const customUiBridgeLinkObservable = link({
+      const customizedLink = customUiBridgeLink({
+        resolverFunctionKey: 'rpc',
         transformer: {
           serialize: (v) => v,
           deserialize: (v) => ({ x: v }),
         },
-        combinedTransformer: mockRuntime.combinedTransformer
-      })({
+      });
+      const customUiBridgeLinkObservable = customizedLink({})({
         op: {
           id: 123,
           type: 'query',
           input: { one: 'abc', two: 'xyz' },
           path: 'test',
           context: {},
+          signal: undefined,
         },
         next: jest.fn(),
       });
 
-      const result = await observableToPromise(customUiBridgeLinkObservable)
-        .promise;
+      const result = await observableToPromise(customUiBridgeLinkObservable);
 
       expect(result).toEqual({
         result: {
@@ -134,13 +123,14 @@ describe('customUiBridgeLink', () => {
         )
       );
 
-      const customUiBridgeLinkObservable = link(mockRuntime)({
+      const customUiBridgeLinkObservable = link({})({
         op: {
           id: 123,
           type: 'query',
           input: { one: 'abc', two: 'xyz' },
           path: 'test',
           context: {},
+          signal: undefined,
         },
         next: jest.fn(),
       });
@@ -150,7 +140,7 @@ describe('customUiBridgeLink', () => {
       expect.assertions(1);
 
       await expect(
-        observableToPromise(customUiBridgeLinkObservable).promise
+        observableToPromise(customUiBridgeLinkObservable)
       ).rejects.toMatchObject({
         name: 'TRPCClientError',
         message: fakeErrorMessage,
@@ -174,7 +164,7 @@ describe('customUiBridgeLink', () => {
       );
 
       const customDeserializerMessage = 'custom-deserializer-message';
-      const customUiBridgeLinkObservable = link({
+      const customizedLink = customUiBridgeLink({
         transformer: {
           serialize: (v) => v,
           deserialize: (v) => ({
@@ -182,14 +172,15 @@ describe('customUiBridgeLink', () => {
             message: customDeserializerMessage,
           }),
         },
-        combinedTransformer: mockRuntime.combinedTransformer
-      })({
+      })
+      const customUiBridgeLinkObservable = customizedLink({})({
         op: {
           id: 123,
           type: 'query',
           input: { one: 'abc', two: 'xyz' },
           path: 'test',
           context: {},
+          signal: undefined,
         },
         next: jest.fn(),
       });
@@ -199,7 +190,7 @@ describe('customUiBridgeLink', () => {
       expect.assertions(1);
 
       await expect(
-        observableToPromise(customUiBridgeLinkObservable).promise
+        observableToPromise(customUiBridgeLinkObservable)
       ).rejects.toMatchObject({
         name: 'TRPCClientError',
         message: customDeserializerMessage,

--- a/packages/forge-trpc-link/src/lib/transform-result.ts
+++ b/packages/forge-trpc-link/src/lib/transform-result.ts
@@ -1,19 +1,20 @@
 import { AnyRouter, inferRouterError } from '@trpc/server';
-import {
-  TRPCResponse,
-  TRPCResponseMessage,
-  TRPCResultMessage,
-} from '@trpc/server/rpc';
-import { TRPCClientError, TRPCClientRuntime } from '@trpc/client';
+import { TRPCResponse, TRPCResponseMessage, TRPCResultMessage } from '@trpc/server/rpc';
+import { TRPCClientError } from '@trpc/client';
+
+interface DataTransformer {
+  serialize: (object: any) => any;
+  deserialize: (object: any) => any;
+}
 
 function transformResultInner<TRouter extends AnyRouter, TOutput>(
   response:
     | TRPCResponseMessage<TOutput, inferRouterError<TRouter>>
     | TRPCResponse<TOutput, inferRouterError<TRouter>>,
-  runtime: TRPCClientRuntime
+  transformer: DataTransformer
 ) {
   if ('error' in response) {
-    const error = runtime.transformer.deserialize(
+    const error = transformer.deserialize(
       response.error
     ) as inferRouterError<TRouter>;
     return {
@@ -29,7 +30,7 @@ function transformResultInner<TRouter extends AnyRouter, TOutput>(
     ...response.result,
     ...((!response.result.type || response.result.type === 'data') && {
       type: 'data',
-      data: runtime.transformer.deserialize(response.result.data),
+      data: transformer.deserialize(response.result.data),
     }),
   } as TRPCResultMessage<TOutput>['result'];
   return { ok: true, result } as const;
@@ -55,12 +56,12 @@ export function transformResult<TRouter extends AnyRouter, TOutput>(
   response:
     | TRPCResponseMessage<TOutput, inferRouterError<TRouter>>
     | TRPCResponse<TOutput, inferRouterError<TRouter>>,
-  runtime: TRPCClientRuntime
+  transformer: DataTransformer
 ): ReturnType<typeof transformResultInner> {
   let result: ReturnType<typeof transformResultInner>;
   try {
     // Use the data transformers on the JSON-response
-    result = transformResultInner(response, runtime);
+    result = transformResultInner(response, transformer);
   } catch (err) {
     throw new TRPCClientError('Unable to transform response from server');
   }


### PR DESCRIPTION
This introduces trpc 11 support as a breaking change. All changes are mainly around the shift of the transformer api from the client to the links. https://trpc.io/docs/migrate-from-v10-to-v11#transformers-are-moved-to-links-breaking