### PR TITLE
feat: update trpc to rc.795

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ With tRPC we get the same benefits as with GraphQL and more (minus the code gene
 * Developer ergonomics: Through the tRCP interface, IDEs will provide code completion for available Forge functions and even support jump-to-source (server) from Custom UI code.
 
 ## tRPC v11
-Starting version 1.0.0 this packages supports tRPC v11 [which is considered stable](https://trpc.io/docs/migrate-from-v10-to-v11). This package is currently tested with 11.0.0-rc.593. Be aware that you'll need to use React 18.x to use tRPC 11.x with react-query 5.x. If you spot any issues with tRPC 11.x please open an issue. 
+Starting version 1.0.0 this packages supports tRPC v11 [which is considered stable](https://trpc.io/docs/migrate-from-v10-to-v11). This package is currently tested with 11.0.0-rc.795. Be aware that you'll need to use React 18.x to use tRPC 11.x with react-query 5.x. If you spot any issues with tRPC 11.x please open an issue. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@forge/bridge": "^3.3.0",
         "@forge/resolver": "^1.5.29",
-        "@trpc/client": "^11.0.0-rc.593",
-        "@trpc/server": "^11.0.0-rc.593",
+        "@trpc/client": "^11.0.0-rc.795",
+        "@trpc/server": "^11.0.0-rc.795",
         "fp-ts": "^2.13.1",
         "io-ts": "^2.2.20",
         "tslib": "^2.3.0"
@@ -42,7 +42,7 @@
         "prettier": "^2.6.2",
         "ts-jest": "29.1.2",
         "ts-node": "10.9.1",
-        "typescript": "5.3.3",
+        "typescript": "5.7.3",
         "verdaccio": "^5.0.4"
       }
     },
@@ -3595,6 +3595,20 @@
         }
       }
     },
+    "node_modules/@nx/eslint/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@nx/jest": {
       "version": "18.1.2",
       "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-18.1.2.tgz",
@@ -4281,25 +4295,29 @@
       }
     },
     "node_modules/@trpc/client": {
-      "version": "11.0.0-rc.593",
-      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.0.0-rc.593.tgz",
-      "integrity": "sha512-uQORhYMwUeY4TluQmhl6N183BiLZz5mgIzBynkSWKxtQ7TIHt+3iRzTSiJH1jTl3SEOtCacRHS6b1yvFP2RJXw==",
+      "version": "11.0.0-rc.795",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.0.0-rc.795.tgz",
+      "integrity": "sha512-t4KCvYr/jI5pmdD0zO5cukarVLN58g1PwV5Lsm5WJyR4TZuIUqIyQZVSm7uM2abBabOSv39P8myK9nFc5yPFdg==",
       "funding": [
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
       "peerDependencies": {
-        "@trpc/server": "11.0.0-rc.593+f73cd3fd9"
+        "@trpc/server": "11.0.0-rc.795+394b0f5cc",
+        "typescript": ">=5.7.2"
       }
     },
     "node_modules/@trpc/server": {
-      "version": "11.0.0-rc.593",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.0.0-rc.593.tgz",
-      "integrity": "sha512-ihZNf7nM3OriZkkuOUFjuB51FJdtCXZUUj8FIXkq0VXF9VmMOD7j4QTl5YojIzMTJBMGUK9VADcO0shgELEmyw==",
+      "version": "11.0.0-rc.795",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.0.0-rc.795.tgz",
+      "integrity": "sha512-rJ5TdCGN4cOb7eSf3zXbWqGMA1XZabtmBOojbNiru2ZujuHGJDmWyKzv/GI2a/j/C/VhUmVU6NRKeLFg3NVERA==",
       "funding": [
         "https://trpc.io/sponsor"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.7.2"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -12290,10 +12308,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15671,6 +15689,14 @@
         "eslint": "^8.0.0",
         "tslib": "^2.3.0",
         "typescript": "~5.3.2"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+          "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+          "dev": true
+        }
       }
     },
     "@nx/eslint-plugin": {
@@ -16128,15 +16154,16 @@
       "dev": true
     },
     "@trpc/client": {
-      "version": "11.0.0-rc.593",
-      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.0.0-rc.593.tgz",
-      "integrity": "sha512-uQORhYMwUeY4TluQmhl6N183BiLZz5mgIzBynkSWKxtQ7TIHt+3iRzTSiJH1jTl3SEOtCacRHS6b1yvFP2RJXw==",
+      "version": "11.0.0-rc.795",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.0.0-rc.795.tgz",
+      "integrity": "sha512-t4KCvYr/jI5pmdD0zO5cukarVLN58g1PwV5Lsm5WJyR4TZuIUqIyQZVSm7uM2abBabOSv39P8myK9nFc5yPFdg==",
       "requires": {}
     },
     "@trpc/server": {
-      "version": "11.0.0-rc.593",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.0.0-rc.593.tgz",
-      "integrity": "sha512-ihZNf7nM3OriZkkuOUFjuB51FJdtCXZUUj8FIXkq0VXF9VmMOD7j4QTl5YojIzMTJBMGUK9VADcO0shgELEmyw=="
+      "version": "11.0.0-rc.795",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.0.0-rc.795.tgz",
+      "integrity": "sha512-rJ5TdCGN4cOb7eSf3zXbWqGMA1XZabtmBOojbNiru2ZujuHGJDmWyKzv/GI2a/j/C/VhUmVU6NRKeLFg3NVERA==",
+      "requires": {}
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
@@ -22101,10 +22128,9 @@
       }
     },
     "typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@forge/bridge": "^3.3.0",
     "@forge/resolver": "^1.5.29",
-    "@trpc/client": "^11.0.0-rc.593",
-    "@trpc/server": "^11.0.0-rc.593",
+    "@trpc/client": "^11.0.0-rc.795",
+    "@trpc/server": "^11.0.0-rc.795",
     "fp-ts": "^2.13.1",
     "io-ts": "^2.2.20",
     "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prettier": "^2.6.2",
     "ts-jest": "29.1.2",
     "ts-node": "10.9.1",
-    "typescript": "5.3.3",
+    "typescript": "5.7.3",
     "verdaccio": "^5.0.4"
   },
   "nx": {

--- a/packages/forge-trpc-adapter/package.json
+++ b/packages/forge-trpc-adapter/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@forge/resolver": "^1.4.8",
     "@toolsplus/forge-trpc-protocol": "0.0.0-development",
-    "@trpc/server": "^11.0.0-rc.593",
+    "@trpc/server": "^11.0.0-rc.795",
     "fp-ts": "^2.13.1",
     "io-ts": "^2.2.20",
     "tslib": "^2.3.0"

--- a/packages/forge-trpc-adapter/src/lib/resolve-procedure-call.ts
+++ b/packages/forge-trpc-adapter/src/lib/resolve-procedure-call.ts
@@ -7,7 +7,7 @@ import { pipe } from 'fp-ts/function';
 import * as PathReporter from 'io-ts/PathReporter';
 import {
   AnyRouter,
-  callProcedure,
+  callTRPCProcedure,
   getErrorShape,
   inferRouterContext,
   inferRouterError,
@@ -175,8 +175,8 @@ const callProcedures = <TRouter extends AnyRouter>({
       pipe(
         TE.tryCatch(
           () =>
-            callProcedure({
-              procedures: router._def.procedures,
+            callTRPCProcedure({
+              router,
               path,
               getRawInput: async () => input,
               ctx,

--- a/packages/forge-trpc-link/package.json
+++ b/packages/forge-trpc-link/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "@forge/bridge": "^3.3.0",
     "@toolsplus/forge-trpc-protocol": "0.0.0-development",
-    "@trpc/client": "^11.0.0-rc.593",
-    "@trpc/server": "^11.0.0-rc.593",
+    "@trpc/client": "^11.0.0-rc.795",
+    "@trpc/server": "^11.0.0-rc.795",
     "tslib": "^2.3.0"
   }
 }


### PR DESCRIPTION
This updates trpc to 11.0.0-rc.795, which introduced changes around the TanStack Query integration (https://trpc.io/blog/introducing-tanstack-react-query-client).


